### PR TITLE
feat(fatal chest trap): location choice open_chest, and a chest which kills if opened

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -60,7 +60,7 @@ tasks:
       - task: deploy:new
         vars:
           PROVIDER_ID: "hh"
-          COMMIT:  "yes"
+          COMMIT: "yes"
       - task: find
         vars:
           PROVIDER_ID: "hh"
@@ -200,7 +200,7 @@ tasks:
       - task: deploy:new
         vars:
           PROVIDER_ID: "hh"
-          COMMIT:  "yes"
+          COMMIT: "yes"
       - task: deploy:new
         vars:
           PROVIDER_ID: "caimst"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -57,10 +57,13 @@ tasks:
     cmds:
       - |
       - task: dev:hh:restart
-      - task: deploy:hh-new
-      - |
-        set -e
-        tusk -q -f tusk-arena.yml diamond-find | tee arenaproxy.addr
+      - task: deploy:new
+        vars:
+          PROVIDER_ID: "hh"
+          COMMIT:  "yes"
+      - task: find
+        vars:
+          PROVIDER_ID: "hh"
 
   test:
     desc: run the integration tests
@@ -197,6 +200,7 @@ tasks:
       - task: deploy:new
         vars:
           PROVIDER_ID: "hh"
+          COMMIT:  "yes"
       - task: deploy:new
         vars:
           PROVIDER_ID: "caimst"
@@ -282,12 +286,12 @@ tasks:
 
           # '-- --commit' (utilising .CLI_ARGS) is the idiomatic way to cause the action to commit
 
-
   deploy:new:
     dotenv: [".env.{{.PROVIDER_ID}}"]
     vars:
       PROVIDER_ID: '{{.PROVIDER_ID | default "hh"}}'
       GAS_PRICE: '{{.GAS_PRICE | default ""}}'
+      COMMIT: '{{.COMMIT | default ""}}'
 
     desc: deploy the contracts to hardhat (assumes the local server is listening on 8545)
     cmds:
@@ -314,9 +318,7 @@ tasks:
             --diamond-init-args \
               '[{"typeURIs": ["GAME_TYPE", "TRANSCRIPT_TYPE", "FURNITURE_TYPE"]}]' \
             -f diamond-deploy.json \
-            {{.CLI_ARGS}}
-
-          # '-- --commit' (utilising .CLI_ARGS) is the idiomatic way to cause the action to commit
+            $([ -n '{{.COMMIT}}' ] && echo -n '--commit {{.COMMIT}}' )
 
   find:
     dotenv: [".env.{{.PROVIDER_ID}}"]

--- a/data/maps/map02-furnishings.json
+++ b/data/maps/map02-furnishings.json
@@ -15,11 +15,23 @@
       },
       "meta": {
         "notes": [
-          "adds a finish exit to location 1. note that location 1 does not *have* an exit on this side in the model data",
+          "adds a finish exit to location 8. note that location 1 does not *have* an exit on this side in the model data",
           "there can only be one finish exit, so the id is also its type",
           "items with no id are not added to the index",
           "an id is set by the loader automatically reflecting the position in the items array"
         ]
+      }
+    },
+    {
+      "unique_name": "chest_1",
+      "labels": ["death_condition"],
+      "choiceType": "open_chest",
+      "type": "fatal_chest_trap",
+      "data": {
+        "location": 0
+      },
+      "meta": {
+        "notes": ["adds a fatal trap to location 0"]
       }
     }
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@nomicfoundation/hardhat-toolbox": "^2.0.2",
         "@openzeppelin/merkle-tree": "^1.0.4",
         "@polysensus/chaintrap-contracts": "file:../chaintrap-contracts",
-        "@polysensus/diamond-deploy": "file:../diamond-deploy",
+        "@polysensus/diamond-deploy": "^0.3.1",
         "@rollup/plugin-commonjs": "^23.0.3",
         "@rollup/plugin-json": "^5.0.2",
         "@rollup/plugin-node-resolve": "^15.0.1",
@@ -96,41 +96,6 @@
         "typechain": "^8.1.1",
         "typescript": "^5.0.4",
         "vitest": "^0.29.8"
-      }
-    },
-    "../diamond-deploy": {
-      "name": "@polysensus/diamond-deploy",
-      "version": "0.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^10.0.0",
-        "ethers": "^5.7.2",
-        "glob": "^8.1.0"
-      },
-      "bin": {
-        "diamond-deploy": "dist/deploycli.cjs"
-      },
-      "devDependencies": {
-        "@babel/eslint-parser": "^7.19.1",
-        "@babel/plugin-syntax-import-assertions": "^7.20.0",
-        "@eth-optimism/sdk": "^2.0.2",
-        "@rollup/plugin-commonjs": "^24.0.1",
-        "@rollup/plugin-json": "^6.0.0",
-        "@rollup/plugin-node-resolve": "^15.0.1",
-        "@vitest/coverage-c8": "^0.28.5",
-        "crypto-random": "^2.0.1",
-        "dotenv": "^16.0.3",
-        "eslint": "^8.34.0",
-        "eslint-plugin-import": "^2.27.5",
-        "eslint-plugin-mocha": "^10.1.0",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^6.1.1",
-        "prettier": "^2.8.4",
-        "rollup-plugin-node-globals": "^1.4.0",
-        "rollup-plugin-node-polyfills": "^0.2.1",
-        "rollup-plugin-polyfill-node": "^0.12.0",
-        "vitest": "^0.28.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2643,8 +2608,27 @@
       "link": true
     },
     "node_modules/@polysensus/diamond-deploy": {
-      "resolved": "../diamond-deploy",
-      "link": true
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@polysensus/diamond-deploy/-/diamond-deploy-0.3.1.tgz",
+      "integrity": "sha512-n60AD8ESguYMLsiNBdcZ9q3yOswsPj95A/Dwl4Z4OI/UUwyYTGfGSshV7sSfQXCcJzPs1/d8sZShFmU4FmqKVA==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0",
+        "ethers": "^5.7.2",
+        "glob": "^8.1.0"
+      },
+      "bin": {
+        "diamond-deploy": "dist/deploycli.cjs"
+      }
+    },
+    "node_modules/@polysensus/diamond-deploy/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@nomicfoundation/hardhat-network-helpers": "^1.0.8",
         "@nomicfoundation/hardhat-toolbox": "^2.0.2",
         "@openzeppelin/contracts": "^4.7.3",
-        "@polysensus/diamond-deploy": "file:../diamond-deploy",
+        "@polysensus/diamond-deploy": "^0.3.1",
         "@rari-capital/solmate": "^6.2.0",
         "@rollup/plugin-commonjs": "^24.0.1",
         "@rollup/plugin-node-resolve": "^15.0.2",
@@ -99,7 +99,7 @@
     },
     "../diamond-deploy": {
       "name": "@polysensus/diamond-deploy",
-      "version": "0.2.4",
+      "version": "0.3.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@vitest/coverage-c8": "^0.25.3",
         "argon2": "^0.30.3",
+        "chai-as-promised": "^7.1.1",
         "cli-spinners": "^2.7.0",
         "deep-equal": "^2.2.1",
         "dotenv": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@vitest/coverage-c8": "^0.25.3",
     "argon2": "^0.30.3",
+    "chai-as-promised": "^7.1.1",
     "cli-spinners": "^2.7.0",
     "deep-equal": "^2.2.1",
     "dotenv": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@nomicfoundation/hardhat-toolbox": "^2.0.2",
     "@openzeppelin/merkle-tree": "^1.0.4",
     "@polysensus/chaintrap-contracts": "file:../chaintrap-contracts",
-    "@polysensus/diamond-deploy": "file:../diamond-deploy",
+    "@polysensus/diamond-deploy": "^0.3.1",
     "@rollup/plugin-commonjs": "^23.0.3",
     "@rollup/plugin-json": "^5.0.2",
     "@rollup/plugin-node-resolve": "^15.0.1",

--- a/src/commands/creategame.js
+++ b/src/commands/creategame.js
@@ -133,6 +133,7 @@ async function creategame(program, options) {
 
   const guardian = await prepareGuardian(eventParser, program, options);
 
+  // Note: this will require a furnitureFile if furniture is not alread present in the existing codex data.
   const { codex } = await fetchCodex(program, options);
 
   // everything gets an icon, but don't hit openai unless asked.

--- a/src/lib/abiconst.js
+++ b/src/lib/abiconst.js
@@ -3,6 +3,7 @@ export class ABIName {
   static TranscriptStarted = "TranscriptStarted";
   static TranscriptCompleted = "TranscriptCompleted";
   static TranscriptRegistration = "TranscriptRegistration";
+  static TranscriptParticipantHalted = "TranscriptParticipantHalted";
   static TranscriptMerkleRootSet = "TranscriptMerkleRootSet";
   static TranscriptEntryChoices = "TranscriptEntryChoices";
   static TranscriptEntryCommitted = "TranscriptEntryCommitted";

--- a/src/lib/arenaevent.js
+++ b/src/lib/arenaevent.js
@@ -17,7 +17,7 @@ export const ERC1155URISignature = "URI(string,uint256)";
 /**
  *
  * @param {EventParser} eventParser
- * @returns {ethers.BigNumber}
+ * @returns {ArenaEvent}
  */
 export function getGameCreated(receipt, eventParser) {
   return eventParser.receiptLog(
@@ -99,6 +99,13 @@ export class ArenaEvent {
           profile: msgpack.decode(arrayify(parsedLog.args.profile)),
         };
         break;
+      case ABIName.TranscriptParticipantHalted:
+        arenaEvent.subject = parsedLog.args.participant;
+        arenaEvent.update = {
+          halted: true
+        };
+        break;
+
       case ABIName.TranscriptEntryChoices:
         arenaEvent.subject = parsedLog.args.participant;
         arenaEvent.eid = parsedLog.args.eid;

--- a/src/lib/erc1155metadata/gamecreator.js
+++ b/src/lib/erc1155metadata/gamecreator.js
@@ -271,6 +271,12 @@ export class GameMetadataCreator {
           `all victory transition types must also be listed in transitionTypes`
         );
 
+    for (const ty of options.haltParticipantTransitionTypes ?? [])
+      if (!(ty in transitionTypes))
+        throw new Error(
+          `all halting transition types must also be listed in transitionTypes`
+        );
+
     // if (!options.map) throw new Error("a map is required");
 
     // Note: allowing for an undefined map is a concession to testability
@@ -317,7 +323,8 @@ export class GameMetadataCreator {
     this.initArgs.transitionTypes = options.transitionTypes.map(conditionInput);
     this.initArgs.victoryTransitionTypes =
       options.victoryTransitionTypes.map(conditionInput);
-    this.initArgs.haltParticipantTransitionTypes = [];
+    this.initArgs.haltParticipantTransitionTypes =
+      (options.haltParticipantTransitionTypes ?? []).map(conditionInput);
 
     delete this._pendingOptions["map"];
   }

--- a/src/lib/guardian.js
+++ b/src/lib/guardian.js
@@ -1,4 +1,8 @@
 import { Furniture } from "./map/furniture.js";
+import {
+  FurnitureTypeCodes,
+  FurnitureSingletons,
+} from "./map/furnitureconst.js";
 import { rootLabel, LogicalTopology } from "./maptrie/logical.js";
 import { Minter } from "./minter.js";
 import { TransactRequest } from "./chainkit/transactor.js";
@@ -78,8 +82,12 @@ export class Guardian {
 
   furnishDungeon(furnishings) {
     this.furnishings = new Furniture(furnishings);
-    const finish = this.furnishings.byName(FINISH_EXIT_NAME);
-    this.topology.placeFinish(finish);
+    this.topology.placeFinish(
+      this.furnishings.byName(FurnitureSingletons.finish_exit)
+    );
+    this.topology.placeFurniture(
+      this.furnishings.byType(ObjectType.FatalChestTrap)
+    );
   }
 
   finalizeDungeon() {

--- a/src/lib/guardian.js
+++ b/src/lib/guardian.js
@@ -1,8 +1,4 @@
 import { Furniture } from "./map/furniture.js";
-import {
-  FurnitureTypeCodes,
-  FurnitureSingletons,
-} from "./map/furnitureconst.js";
 import { rootLabel, LogicalTopology } from "./maptrie/logical.js";
 import { Minter } from "./minter.js";
 import { TransactRequest } from "./chainkit/transactor.js";
@@ -81,13 +77,7 @@ export class Guardian {
   }
 
   furnishDungeon(furnishings) {
-    this.furnishings = new Furniture(furnishings);
-    this.topology.placeFinish(
-      this.furnishings.byName(FurnitureSingletons.finish_exit)
-    );
-    this.topology.placeFurniture(
-      this.furnishings.byType(ObjectType.FatalChestTrap)
-    );
+    this.topology.placeFurniture(new Furniture(furnishings));
   }
 
   finalizeDungeon() {
@@ -111,8 +101,9 @@ export class Guardian {
       ...options,
       trialSetupCodex: options.codexPublish ? this.trialSetupCodex : undefined,
       choiceInputTypes: [ObjectType.LocationChoices],
-      transitionTypes: [ObjectType.Link2, ObjectType.Finish],
+      transitionTypes: [ObjectType.Link2, ObjectType.Finish, ObjectType.FatalChestTrap],
       victoryTransitionTypes: [ObjectType.Finish],
+      haltParticipantTransitionTypes: [ObjectType.FatalChestTrap],
     });
     const r = await this.minter.mint({
       topology: this.topology,
@@ -218,6 +209,13 @@ export class Guardian {
             "TranscriptEntryChoices(uint256,address,uint256,(uint256,bytes32[][]),bytes)"
           );
           break;
+        }
+        case ObjectType.FatalChestTrap: {
+          request.requireLogs(
+            "TranscriptParticipantHalted(uint256,address,uint256)"
+          );
+          break;
+
         }
         default:
           throw new Error(`un-expected transitionType`);

--- a/src/lib/journal.js
+++ b/src/lib/journal.js
@@ -112,10 +112,10 @@ export class Journal {
       ethers.utils.formatBytes32String(staticRootLabel);
   }
 
-  locationChoiceArgs(gid, start, exit) {
+  locationChoiceArgs(gid, ...input) {
     return {
       rootLabel: this.staticRootLabel(gid),
-      input: [start, exit].map(conditionInput),
+      input: input.map(conditionInput),
       data: "0x",
     };
   }

--- a/src/lib/map/furnishing.js
+++ b/src/lib/map/furnishing.js
@@ -1,0 +1,42 @@
+import { ObjectType } from "../maptrie/objecttypes.js";
+import { LocationChoiceType } from "../maptrie/inputtypes.js";
+import { titleCase } from "../strings.js";
+
+/**
+ * All located furniture is instanced with this class. Note, this excludes the finish_exit
+ */
+export class Furnishing {
+
+  /**
+   * @param {number} id the identifier the container knows this furnishing by.
+   * @param {{
+   *   unique_name: string|undefined,
+   *   labels: string[],
+   *   type: string,
+   *   choiceType: string,
+   *   data: {location:number, side:number?, exit:number?}
+   *   meta: {notes:string[]?}
+   * }} item
+   */
+  constructor(id, item) {
+    this.id = id;
+    this.type = ObjectType[titleCase(item.type, true /*capitolize*/)];
+    if (typeof this.type === "undefined")
+      throw new Error(`item type ${item.type} not found`);
+    // choiceType may legitemately be undefined
+    this.choiceType = item.choiceType ? LocationChoiceType[titleCase(item.choiceType)] : undefined;
+    this.item = item;
+  }
+  get typeName() {
+    return this.item.type;
+  }
+  get location() {
+    return this.item.data.location;
+  }
+  get uniqueName() {
+    return this.item.unique_name;
+  }
+  get unique() {
+    return typeof this.uniqueName !== "undefined";
+  }
+}

--- a/src/lib/map/furnishing.js
+++ b/src/lib/map/furnishing.js
@@ -6,7 +6,6 @@ import { titleCase } from "../strings.js";
  * All located furniture is instanced with this class. Note, this excludes the finish_exit
  */
 export class Furnishing {
-
   /**
    * @param {number} id the identifier the container knows this furnishing by.
    * @param {{
@@ -24,7 +23,9 @@ export class Furnishing {
     if (typeof this.type === "undefined")
       throw new Error(`item type ${item.type} not found`);
     // choiceType may legitemately be undefined
-    this.choiceType = item.choiceType ? LocationChoiceType[titleCase(item.choiceType)] : undefined;
+    this.choiceType = item.choiceType
+      ? LocationChoiceType[titleCase(item.choiceType)]
+      : undefined;
     this.item = item;
   }
   get typeName() {

--- a/src/lib/map/furniture.js
+++ b/src/lib/map/furniture.js
@@ -1,7 +1,14 @@
+import { FurnitureTypeCodes } from "./furnitureconst.js";
+import { Furnishing } from "./furnishing.js";
 export class Furniture {
   static fromJSON(data) {
     return new Furniture(data);
   }
+
+  /**
+   *
+   * @param {{map,items:[]}} data
+   */
   constructor(data) {
     this.init(data);
   }
@@ -12,25 +19,52 @@ export class Furniture {
     return it;
   }
 
+  byTypeName(typeName) {
+    return this.byType(FurnitureTypeCodes[typeName]);
+  }
+
+  byType(type) {
+    const furns = this.index.types[type];
+    if (!furns) throw new Error(`type ${type} not found`);
+    return [...furns];
+  }
+
+  byLocation(location) {
+    const furns = this.index.located[location];
+    if (!furns) return [];
+    return [...furns];
+  }
+
+
   init(data) {
     this.map = data.map;
     this.items = data.items;
     this.index = {
       types: {},
       identified: {},
+      located: {},
+      typeByIndex: {},
     };
     for (let i = 0; i < this.items.length; i++) {
       const it = this.items[i];
+      const furn = new Furnishing(i, it);
 
-      it.id = i; // the id is the index in the items array
-
-      if (it.unique_name) {
-        if (it.unique_name in this.index.identified)
-          throw new Error(`id ${it.unique_name} previously defined`);
-        this.index.identified[it.unique_name] = it;
+      if (furn.unique) {
+        if (furn.uniqueName in this.index.identified)
+          throw new Error(`id ${furn.uniqueName} previously defined`);
+        this.index.identified[furn.uniqueName] = furn;
       }
-      if (it.type)
-        this.index.types[it.type] = [...(this.index.types[it.type] ?? []), it];
+      this.index.typeByIndex[i] = furn.type;
+      this.index.types[furn.type] = [
+        ...(this.index.types[furn.type] ?? []),
+        furn,
+      ];
+
+      if (typeof furn.location !== "undefined")
+        this.index.located[furn.location] = [
+          ...(this.index.located[furn.location] ?? []),
+          furn,
+        ];
     }
   }
 }

--- a/src/lib/map/furniture.js
+++ b/src/lib/map/furniture.js
@@ -35,7 +35,6 @@ export class Furniture {
     return [...furns];
   }
 
-
   init(data) {
     this.map = data.map;
     this.items = data.items;

--- a/src/lib/map/furniture.mocha.js
+++ b/src/lib/map/furniture.mocha.js
@@ -2,11 +2,20 @@
 import { expect } from "chai";
 
 import { Furniture } from "./furniture.js";
+import { FurnitureTypeCodes } from "./furnitureconst.js";
 import furnishings from "../../../data/maps/map02-furnishings.json" assert { type: "json" };
 
 describe("Furniture tests", function () {
   it("Should load furnishings data", async function () {
     const f = new Furniture(furnishings);
-    expect(f.items.length).to.equal(1);
+    expect(f.items.length).to.equal(2);
+    expect(f.index?.identified['finish_exit']).to.exist;
+    expect(f.index?.identified['chest_1']).to.exist;
+    expect(f.byName('finish_exit')).to.not.throw;
+    expect(f.byName('chest_1')).to.not.throw;
+    expect(f.byType(FurnitureTypeCodes.finish_exit).length).to.equal(1);
+    expect(f.byType(FurnitureTypeCodes.fatal_chest_trap).length).to.equal(1);
+    expect(f.byTypeName('finish_exit')).to.not.throw;
+    expect(f.byTypeName('fatal_chest_trap')).to.not.throw;
   });
 });

--- a/src/lib/map/furniture.mocha.js
+++ b/src/lib/map/furniture.mocha.js
@@ -2,20 +2,20 @@
 import { expect } from "chai";
 
 import { Furniture } from "./furniture.js";
-import { FurnitureTypeCodes } from "./furnitureconst.js";
+import { ObjectType } from "../maptrie/objecttypes.js";
 import furnishings from "../../../data/maps/map02-furnishings.json" assert { type: "json" };
 
 describe("Furniture tests", function () {
   it("Should load furnishings data", async function () {
     const f = new Furniture(furnishings);
     expect(f.items.length).to.equal(2);
-    expect(f.index?.identified['finish_exit']).to.exist;
-    expect(f.index?.identified['chest_1']).to.exist;
-    expect(f.byName('finish_exit')).to.not.throw;
-    expect(f.byName('chest_1')).to.not.throw;
-    expect(f.byType(FurnitureTypeCodes.finish_exit).length).to.equal(1);
-    expect(f.byType(FurnitureTypeCodes.fatal_chest_trap).length).to.equal(1);
-    expect(f.byTypeName('finish_exit')).to.not.throw;
-    expect(f.byTypeName('fatal_chest_trap')).to.not.throw;
+    expect(f.index?.identified["finish_exit"]).to.exist;
+    expect(f.index?.identified["chest_1"]).to.exist;
+    expect(f.byName("finish_exit")).to.not.throw;
+    expect(f.byName("chest_1")).to.not.throw;
+    expect(f.byType(ObjectType.FinishExit).length).to.equal(1);
+    expect(f.byType(ObjectType.FatalChestTrap).length).to.equal(1);
+    expect(f.byTypeName("finish_exit")).to.not.throw;
+    expect(f.byTypeName("fatal_chest_trap")).to.not.throw;
   });
 });

--- a/src/lib/map/furnitureconst.js
+++ b/src/lib/map/furnitureconst.js
@@ -1,0 +1,8 @@
+export class FurnitureTypeCodes {
+  static finish_exit = 1;
+  static fatal_chest_trap = 2;
+}
+
+export class FurnitureSingletons {
+  static finish_exit = "finish_exit";
+}

--- a/src/lib/map/furnitureconst.js
+++ b/src/lib/map/furnitureconst.js
@@ -1,6 +1,7 @@
+import { ObjectType } from "../maptrie/objecttypes.js";
 export class FurnitureTypeCodes {
-  static finish_exit = 1;
-  static fatal_chest_trap = 2;
+  static finish_exit = ObjectType.FinishExit;
+  static fatal_chest_trap = ObjectType.FatalChestTrap;
 }
 
 export class FurnitureSingletons {

--- a/src/lib/maptrie/inputtypes.js
+++ b/src/lib/maptrie/inputtypes.js
@@ -1,0 +1,20 @@
+/*
+ LocationChoices have at leat 4 choice menus.
+ 
+ The first four are the 'side' menues representing the 4 sides of each location
+ and the exits available on each respective side.
+
+ Subsequent menus are identified by the following constants.
+ */
+
+export class LocationChoiceType {
+  // For consistency, represent the sides as choice types also
+  static North = 0;
+  static West = 1;
+  static South = 2;
+  static East = 3;
+
+  // Each menu entry identifies a chest that can be opened at this location.
+  // The consequences of opening are not inferable from the id.
+  static OpenChest = 4;
+}

--- a/src/lib/maptrie/inputtypes.js
+++ b/src/lib/maptrie/inputtypes.js
@@ -13,6 +13,7 @@ export class LocationChoiceType {
   static West = 1;
   static South = 2;
   static East = 3;
+  static LastSideChoice = 3;
 
   // Each menu entry identifies a chest that can be opened at this location.
   // The consequences of opening are not inferable from the id.

--- a/src/lib/maptrie/locationchoices.js
+++ b/src/lib/maptrie/locationchoices.js
@@ -15,9 +15,16 @@ export class LocationChoices {
   static LOCATION_INPUT = 0;
   static CHOICE_INPUTS = 1;
 
-  constructor(location, sideExits) {
+  /**
+   *
+   * @param {number} location
+   * @param {[[]]} sideExits
+   * @param {[[]]} furniture
+   */
+  constructor(location, sideExits, furniture) {
     this.location = location;
     this.sideExits = sideExits;
+    this.furniture = furniture;
   }
 
   /**
@@ -45,13 +52,19 @@ export class LocationChoices {
   }
 
   inputs(options) {
-    if (!options.unconditioned)
-      return [
+    if (!options.unconditioned) {
+      let conditioned = [
         [conditionInput(this.location)],
-        ...conditionInputs(this.sideExits),
-      ];
-
-    return [[this.location], ...this.sideExits];
+        ...conditionInputs(this.sideExits)
+      ]
+      if (this.furniture?.length > 0)
+        conditioned = [...conditioned, ...conditionInputs(this.furniture)];
+      return conditioned;
+    }
+    let unconditioned = [[this.location], ...this.sideExits];
+    if (this.furniture?.length > 0)
+      unconditioned = [...unconditioned, ...this.furniture];
+    return unconditioned;
   }
 
   /**

--- a/src/lib/maptrie/locationchoices.js
+++ b/src/lib/maptrie/locationchoices.js
@@ -55,8 +55,8 @@ export class LocationChoices {
     if (!options.unconditioned) {
       let conditioned = [
         [conditionInput(this.location)],
-        ...conditionInputs(this.sideExits)
-      ]
+        ...conditionInputs(this.sideExits),
+      ];
       if (this.furniture?.length > 0)
         conditioned = [...conditioned, ...conditionInputs(this.furniture)];
       return conditioned;

--- a/src/lib/maptrie/locationfurnishing.js
+++ b/src/lib/maptrie/locationfurnishing.js
@@ -8,7 +8,7 @@ import { conditionInputs } from "./objects.js";
 import { LogicalRef } from "./logicalref.js";
 
 /**
- * [CHOICE-TYPE, [[FURNITURE-TYPE], [REF(#L, i)]]]
+ * [FURNITURE-TYPE, [[CHOICE-TYPE], [REF(#L, i)]]]
  */
 export class LocationFurnishing {
   // static ObjectType = ObjectType.Chest;
@@ -17,7 +17,7 @@ export class LocationFurnishing {
    * @param {import('../logicalref.js').LogicalRef} inputRef
    */
   constructor(furn, inputRef) {
-    this.furn = furn
+    this.furn = furn;
     this.inputRef = inputRef;
   }
 
@@ -28,9 +28,8 @@ export class LocationFurnishing {
         `a reference resolver is required to prepare LocationExit instances`
       );
 
-    const inputs = [[this.furn.type], resolveValue(this.inputRef)];
-    if (!options.unconditioned)
-      return conditionInputs(inputs);
+    const inputs = [[this.furn.choiceType], resolveValue(this.inputRef)];
+    if (!options.unconditioned) return conditionInputs(inputs);
     return inputs;
   }
 
@@ -39,6 +38,6 @@ export class LocationFurnishing {
    * @returns
    */
   prepare(options) {
-    return [this.furn.choiceType, this.inputs(options)];
+    return [this.furn.type, this.inputs(options)];
   }
 }

--- a/src/lib/maptrie/locationfurnishing.js
+++ b/src/lib/maptrie/locationfurnishing.js
@@ -1,0 +1,44 @@
+/**
+ * Encodes the chests available to the location menu. These form the
+ * basis of the location chest based traps and treats
+ */
+
+import { conditionInputs } from "./objects.js";
+
+import { LogicalRef } from "./logicalref.js";
+
+/**
+ * [CHOICE-TYPE, [[FURNITURE-TYPE], [REF(#L, i)]]]
+ */
+export class LocationFurnishing {
+  // static ObjectType = ObjectType.Chest;
+
+  /**
+   * @param {import('../logicalref.js').LogicalRef} inputRef
+   */
+  constructor(furn, inputRef) {
+    this.furn = furn
+    this.inputRef = inputRef;
+  }
+
+  inputs(options) {
+    const resolveValue = options?.resolveValue;
+    if (!resolveValue)
+      throw new Error(
+        `a reference resolver is required to prepare LocationExit instances`
+      );
+
+    const inputs = [[this.furn.type], resolveValue(this.inputRef)];
+    if (!options.unconditioned)
+      return conditionInputs(inputs);
+    return inputs;
+  }
+
+  /**
+   * @param {{resolveValue(ref:LogicalRef):string|number}} options
+   * @returns
+   */
+  prepare(options) {
+    return [this.furn.choiceType, this.inputs(options)];
+  }
+}

--- a/src/lib/maptrie/logical.entryCommit.mocha.js
+++ b/src/lib/maptrie/logical.entryCommit.mocha.js
@@ -48,14 +48,19 @@ describe("LogicalTopology entryCommit tests", function () {
         },
       ],
     });
-    topo.placeFinish(furniture.byName("finish_exit"));
+    topo.placeFurniture(furniture);
     const trie = topo.commit();
 
     // mint without publishing nft metadata
     this.minter.applyOptions({
       choiceInputTypes: [ObjectType.LocationChoices],
-      transitionTypes: [ObjectType.Link2, ObjectType.Finish],
+      transitionTypes: [
+        ObjectType.Link2,
+        ObjectType.Finish,
+        ObjectType.FatalChestTrap,
+      ],
       victoryTransitionTypes: [ObjectType.Finish],
+      haltParticipantTransitionTypes: [ObjectType.FatalChestTrap],
     });
     let r = await this.mintGame({ topology: topo, trie });
 

--- a/src/lib/maptrie/logical.js
+++ b/src/lib/maptrie/logical.js
@@ -12,6 +12,7 @@ import { ObjectCodec, LeafObject, leafHash } from "./objects.js";
 import { ObjectType } from "./objecttypes.js";
 import { LogicalRef, LogicalRefType } from "./logicalref.js";
 import { Location } from "./location.js";
+import { LocationFurnishing } from "./locationfurnishing.js";
 
 export function rootLabel(map) {
   if (!map)
@@ -101,6 +102,13 @@ export class LogicalTopology {
     this.locationExitLinksProof = [];
     this.locationExitLinkKeys = {};
 
+    this.furnLeafs = [];
+    this.furnPrepared = [];
+    this.furnProof = [];
+    this.furnKeys = {};
+    // `${location}:${<ChoiceInputType>}:${furnIndex}` furnIndex means the i'th chest in the location, it doesn't index anywhere else. it is refered to by the furniture leaves.
+    this.locationFurn = {};
+
     this._trie = undefined;
     this._committed = false;
   }
@@ -162,6 +170,9 @@ export class LogicalTopology {
   placeFinish(finish) {
     this.finish = finish;
   }
+  placeFurniture(furniture) {
+    this.furniture = furniture;
+  }
 
   /**
    * Commit the whole map topology to a merkle trie, building a cache of entries
@@ -176,27 +187,28 @@ export class LogicalTopology {
 
     for (let locationId = 0; locationId < this.locations.length; locationId++) {
       const sideExits = this.locationExitChoices(locationId); // the flattened list of [[side, exit], ...., [side, exit]]
+      const furnitureChoices = this.locationFurnitureChoices(locationId); // [[OpenChest, 0], ..., [OpenChest, n]
 
-      if (this.finish.data.location === locationId) {
+      if (this.finish.item.data.location === locationId) {
         // check the finish does not conflict with a side, exit from the generated map
         for (const [side, exit] of sideExits)
-          if (this.finish.data.side === side && this.finish.data.exit === exit)
+          if (this.finish.item.data.side === side && this.finish.item.data.exit === exit)
             throw new Error(`finish placement conflicts with map exit`);
-        sideExits.push([this.finish.data.side, this.finish.data.exit]);
+        sideExits.push([this.finish.item.data.side, this.finish.item.data.exit]);
       }
-      const location = new LocationChoices(locationId, sideExits);
+      const location = new LocationChoices(locationId, sideExits, furnitureChoices.choices);
 
-      let leaf = new LeafObject({
+      let leafObject = new LeafObject({
         type: LocationChoices.ObjectType,
         leaf: location,
       });
-      let prepared = this.prepareLeaf(leaf);
+      let prepared = this.prepareLeaf(leafObject);
 
       let key = leafHash(prepared);
       if (key in this.locationChoicesKeys)
         throw new Error(`locations are expected to be naturally unique`);
 
-      this.locationChoices.push(leaf);
+      this.locationChoices.push(leafObject);
       this.locationChoicesPrepared.push(prepared);
       this.locationChoicesProof.push();
       this.locationChoicesKeys[key] = this.locationChoices.length - 1;
@@ -212,32 +224,62 @@ export class LogicalTopology {
 
         // if we placed the finish exit in this location, build the choices accordingly
         if (
-          this.finish.data.location === locationId &&
+          this.finish.item.data.location === locationId &&
           j === sideExits.length - 1
         ) {
-          leaf = new LeafObject({
+          leafObject = new LeafObject({
             type: FinishExit.ObjectType,
             leaf: new FinishExit(locationChoiceRef),
           });
           this.finishExitId = this.exits.length; // it is added below
           this.finishLocationId = this.locationChoices.length - 1; // it was added above
         } else {
-          leaf = new LeafObject({
+          leafObject = new LeafObject({
             type: LocationExit.ObjectType,
             leaf: new LocationExit(locationChoiceRef),
           });
         }
 
-        prepared = this.prepareLeaf(leaf);
+        prepared = this.prepareLeaf(leafObject);
         key = leafHash(prepared);
 
-        const locationExitIndex = this.exits.length;
-        this.exitKeys[key] = locationExitIndex;
+        const id = this.exits.length;
+        this.exitKeys[key] = id;
         this.locationExits[
           `${locationId}:${sideExits[j][0]}:${sideExits[j][1]}`
-        ] = locationExitIndex;
-        this.exits.push(leaf);
+        ] = id;
+        this.exits.push(leafObject);
         this.exitsPrepared.push(prepared);
+      }
+
+      // We need a node for all furniture placed at specific locations. (except
+      // for the finish exit which is a special exit)
+
+      // Create the choice references for the chests placed at this location
+      const furniture = furnitureChoices.furniture;
+      for (let j = 0; j < furniture.length; j++) {
+
+        const furn = furniture[j];
+
+        const locationChoiceRef = new LogicalRef(
+          LogicalRefType.ProofInput,
+          ObjectType.LocationChoices,
+          locationId,
+          location.iChoices() + sideExits.length + j
+        );
+        leafObject = new LeafObject({
+          type: furn.type,
+          leaf: new LocationFurnishing(furn, locationChoiceRef),
+        });
+        prepared = this.prepareLeaf(leafObject);
+        key = leafHash(prepared);
+
+        this.furnKeys[key] = furn.id; // leaf hash -> this.furniture.items[index]
+        this.locationFurn[
+          `${locationId}:${furn.choiceType}:${j}`
+        ] = furn.id;
+        this.furnLeafs.push(leafObject);
+        this.furnPrepared.push(prepared);
       }
     }
 
@@ -271,6 +313,7 @@ export class LogicalTopology {
         ...this.locationChoicesPrepared,
         ...this.exitsPrepared,
         ...this.locationExitLinksPrepared,
+        ...this.furnPrepared
       ],
       LeafObject.ABI
     );
@@ -283,6 +326,9 @@ export class LogicalTopology {
 
     for (const prepared of this.locationExitLinksPrepared)
       this.locationExitLinksProof.push(this.trie.getProof(prepared));
+
+    for (const prepared of this.furnPrepared)
+      this.furnProof.push(this.trie.getProof(prepared));
 
     this._committed = true;
     return this.trie;
@@ -343,6 +389,15 @@ export class LogicalTopology {
     return id;
   }
 
+  furnitureId(location, choiceType, index) {
+    const id = this.locationFurnuture[`${location}:${choiceType}:${index}`];
+    if (typeof id === 'undefined')
+      throw new Error(
+        `location furniture not found for ${location}:${choiceType}:${index}`
+      );
+    return id;
+  }
+
   /**
    *
    * @param {number} typeId
@@ -357,6 +412,10 @@ export class LogicalTopology {
         return this.exits[id];
       case ObjectType.Link2:
         return this.locationExitLinks[id];
+      case ObjectType.FinishExit:
+        return this.furnLeafts[id];
+      case ObjectType.FatalChestTrap:
+        return this.furnLeafts[id];
     }
     return undefined;
   }
@@ -413,6 +472,27 @@ export class LogicalTopology {
         choices.push([side, exit]);
     }
     return choices;
+  }
+
+  locationFurnitureChoices(location) {
+
+    if (!this.furniture) return [];
+
+    // The first 4 choice entries are the 'sides', further entries will have
+    // fixed meaning. The first such entry represents a list of openable chests
+    // [sides 0-3, [ChoiceType, ], [open, chest-b], ...]]
+    const choices = [];
+
+    const furniture = this.furniture.byLocation(location);
+    const choosable = []; // FinishExits are furniture but they are handled as exits
+
+    for (let i = 0; i < furniture.length; i++) {
+      const furn = furniture[i];
+      if (typeof furn.choiceType === 'undefined') continue;
+      choices.push([furn.choiceType, i])
+      choosable.push(furn)
+    }
+    return {furniture:choosable, choices};
   }
 
   /**

--- a/src/lib/maptrie/logical.mocha.js
+++ b/src/lib/maptrie/logical.mocha.js
@@ -25,7 +25,7 @@ import { Furniture } from "../map/furniture.js";
 const { map02 } = maps;
 
 describe("LogicalTopology tests", function () {
-  it("Should build merkle for standard test map map", function () {
+  it("Should build merkle for standard test map", function () {
     const topo = new LogicalTopology();
     topo.extendJoins(map02.model.corridors); // rooms 0,1 sides EAST, WEST
     topo.extendLocations(map02.model.rooms);
@@ -39,6 +39,23 @@ describe("LogicalTopology tests", function () {
       console.log("Proof:", proof);
     }
   });
+
+  it("Should build merkle for standard furnished test map", function () {
+    const topo = new LogicalTopology();
+    topo.extendJoins(map02.model.corridors); // rooms 0,1 sides EAST, WEST
+    topo.extendLocations(map02.model.rooms);
+    const furniture = new Furniture(furnishings);
+    topo.placeFinish(furniture.byName("finish_exit"));
+    topo.placeFurniture(furniture);
+    const trie = topo.commit();
+
+    for (const [i, v] of trie.entries()) {
+      const proof = trie.getProof(i);
+      console.log("Value:", v);
+      console.log("Proof:", proof);
+    }
+  });
+
 
   it("Should throw because join and location access disagree", function () {
     const topo = new LogicalTopology();

--- a/src/lib/maptrie/logical.mocha.js
+++ b/src/lib/maptrie/logical.mocha.js
@@ -56,7 +56,6 @@ describe("LogicalTopology tests", function () {
     }
   });
 
-
   it("Should throw because join and location access disagree", function () {
     const topo = new LogicalTopology();
     topo.extendJoins([{ joins: [0, 1], sides: [3, 1] }]); // rooms 0,1 sides EAST, WEST

--- a/src/lib/maptrie/logical.setStart.mocha.js
+++ b/src/lib/maptrie/logical.setStart.mocha.js
@@ -41,17 +41,31 @@ describe("LogicalTopology setStart tests", function () {
           type: "finish_exit",
           data: { location: 1, side: 3, exit: 0 },
         },
+        {
+          unique_name: "chest_1",
+          labels: ["death_condition"],
+          choiceType: "open_chest",
+          type: "fatal_chest_trap",
+          data: {
+            location: 0,
+          },
+        },
       ],
     });
-    topo.placeFinish(furniture.byName("finish_exit"));
+    topo.placeFurniture(furniture);
 
     const trie = topo.commit();
 
     // mint without publishing nft metadata
     this.minter.applyOptions({
       choiceInputTypes: [ObjectType.LocationChoices],
-      transitionTypes: [ObjectType.Link2, ObjectType.Finish],
+      transitionTypes: [
+        ObjectType.Link2,
+        ObjectType.Finish,
+        ObjectType.FatalChestTrap,
+      ],
       victoryTransitionTypes: [ObjectType.Finish],
+      haltParticipantTransitionTypes: [ObjectType.FatalChestTrap],
     });
     let r = await this.mintGame({ topology: topo, trie: trie });
 

--- a/src/lib/maptrie/objects.js
+++ b/src/lib/maptrie/objects.js
@@ -116,7 +116,6 @@ export class LeafObject {
 }
 
 export class ObjectCodec {
-
   /**
    * Prepare a LeafObject to be ethers ABI encoded according to {@link LeafObject.ABI}
    * The round trip looks like this:
@@ -126,7 +125,6 @@ export class ObjectCodec {
    * @param {LeafObject} o
    */
   static prepare(o, options) {
-
     // TODO: decide if we really wan't the ObjectCodec at all
     const [typeId, inputs] = o.leaf.prepare(options);
 

--- a/src/lib/maptrie/objects.js
+++ b/src/lib/maptrie/objects.js
@@ -116,13 +116,6 @@ export class LeafObject {
 }
 
 export class ObjectCodec {
-  static typePrepare = Object.fromEntries([
-    [ObjectType.Exit, (leaf, options) => leaf.prepare(options)],
-    [ObjectType.LocationChoices, (leaf, options) => leaf.prepare(options)],
-    [ObjectType.Link2, (leaf, options) => leaf.prepare(options)],
-    [ObjectType.Finish, (leaf, options) => leaf.prepare(options)],
-    [ObjectType.FinishLink, (leaf, options) => leaf.prepare(options)],
-  ]);
 
   /**
    * Prepare a LeafObject to be ethers ABI encoded according to {@link LeafObject.ABI}
@@ -133,10 +126,9 @@ export class ObjectCodec {
    * @param {LeafObject} o
    */
   static prepare(o, options) {
-    const preper = ObjectCodec.typePrepare[o.type];
-    if (!preper) throw new Error(`type ${o.type} not configured`);
 
-    const [typeId, inputs] = preper(o.leaf, options);
+    // TODO: decide if we really wan't the ObjectCodec at all
+    const [typeId, inputs] = o.leaf.prepare(options);
 
     return [typeId, directPreimage(inputs)];
   }

--- a/src/lib/maptrie/objecttypes.js
+++ b/src/lib/maptrie/objecttypes.js
@@ -5,4 +5,6 @@ export class ObjectType {
   static Link2 = 8;
   static LocationChoices = 9;
   static Finish = 10;
+  static FinishExit = 11;
+  static FatalChestTrap = 12;
 }

--- a/src/lib/strings.js
+++ b/src/lib/strings.js
@@ -1,0 +1,16 @@
+/**
+ * Convert snake case strings like foo_bar_baz to fooBarBaz.
+ *
+ * Pass true for optional parameter capitolize to get FooBarBaz
+ *
+ * @param {string} snakeCase  foo_bar snake case like string
+ * @param {boolean} capitolize pass 'true' to get FooBar rather than fooBar
+ */
+export function titleCase(snakeCase, capitolize = false) {
+  const parts = snakeCase.split("_");
+  let titleCased = parts
+    .map((word) => word.charAt(0).toUpperCase() + word.substr(1).toLowerCase())
+    .join("");
+  if (!capitolize) titleCased.charAt(0).toLowerCase();
+  return titleCased;
+}

--- a/src/lib/trial.twoMoveDeath.mocha.js
+++ b/src/lib/trial.twoMoveDeath.mocha.js
@@ -1,5 +1,8 @@
 // @ts-check
-import { expect } from "chai";
+import { expect, use as chaiUse } from "chai";
+// import * as chaiAsPromised from "chai-as-promised";
+// chaiUse(chaiAsPromised);
+
 import { ethers } from "ethers";
 
 import { Guardian } from "./guardian.js";
@@ -15,8 +18,8 @@ import { Dispatcher } from "./chainkit/dispatcher.js";
 const defaultMaxWait = 4000;
 const defaultInterval = 500;
 
-describe("Game session victory tests", function () {
-  it("Should complete game in two moves", async function () {
+describe("Game session participant halt tests", function () {
+  it("Should halt participant in two moves", async function () {
     if (!this.gameOptions) {
       this.skip();
     }
@@ -60,7 +63,8 @@ describe("Game session victory tests", function () {
       interval: pollingInterval,
       logBanner: "trialist: ",
     });
-    await trialist.commitLocationChoice(gid, 1, 0); // -> location 8
+    // await trialist.commitLocationChoice(gid, 1, 0); // -> location 8
+    await trialist.commitLocationChoice(gid, 4, 0); // -> open_chest
 
     await guardian.journal?.waitPendingOutcomes(gid, 1, {
       interval: pollingInterval,
@@ -76,17 +80,7 @@ describe("Game session victory tests", function () {
     // contract.
     await trialist.startListening(gid);
     await trialist.journal?.waitOutcomeResolutions(gid);
-    await trialist.commitLocationChoice(gid, 0, 0); // -> finish_exit
-
-    await guardian.journal?.waitPendingOutcomes(gid, 1, {
-      pollingInterval,
-      logBanner: "guardian: ",
-    });
-    resolved = await guardian.resolvePending(gid);
-    expect(resolved.length).to.equal(1);
-
-    // TODO: close the game on victory and transfer the transcript nft to the victor.
-
-    // now commit to the victory choice
+    // Check that an attempt by the halted participant to make further choices is rejected with the appropriate error.
+    expect(trialist.commitLocationChoice(gid, 0, 0)).to.be.rejectedWith(/.*/, 'Transcript_ParticipantHalted()');
   });
 });

--- a/src/lib/trialist.js
+++ b/src/lib/trialist.js
@@ -38,8 +38,8 @@ export class Trialist {
     return await this.journal.startListening([gid], options);
   }
 
-  async commitLocationChoice(gid, side, exit) {
-    const args = this.journal.locationChoiceArgs(gid, side, exit);
+  async commitLocationChoice(gid, ...input) {
+    const args = this.journal.locationChoiceArgs(gid, ...input);
 
     const request = new TransactRequest(this.eventParser);
     request

--- a/src/lib/trialiststate.js
+++ b/src/lib/trialiststate.js
@@ -5,6 +5,7 @@ import { PropDelta } from "./propdelta.js";
 
 export const TrialistEvents = Object.fromEntries([
   [ABIName.TranscriptRegistration, true],
+  [ABIName.TranscriptParticipantHalted, true],
   [ABIName.TranscriptEntryChoices, true],
   [ABIName.TranscriptEntryCommitted, true],
   [ABIName.TranscriptEntryOutcome, true],
@@ -29,6 +30,7 @@ export class TrialistState {
     this.propDelta = new PropDelta(
       [
         "registered",
+        "halted",
         "address",
         "profile",
         "rootLabel",


### PR DESCRIPTION
Introduces general furniture type which can be acted upon using the location choice menu introduced for chosing exits.

A furntiture merkle leaf is defined as:

    {FURNITURE-TYPE, [[CHOICE-TYPE], [REF(#L, i)]]}

The CHOICE-TYPE "open_chest" is introduced.

The FURNITURE-TYPE "fatal_chest_trap" is introduced.

Choice set transition types which halt individual participants are introduced. When a stack proof which has a halting choiceSetType is proven, the participant is 'halted' and no further moves will be accepted for that participant.

The location choice set for a room with an exit on the nort and south sides would look like this:

    {LOCATION_CHOICE, [[locationId], [0, 0], [2, 0]]}

We treat the directionals NORTH, WEST, SOUTH, EAST as the first 4 valid choice types, aka "north_exit", "east_exit" and so on.

The location menu for the same location with a single fatal chest trap lying on the floor will look like this

    {LOCATION_CHOICE, [[locationId], [0, 0], [2, 0], [4, 0]}

The CHOICE-TYPE for "open_chest" is 4.

The ` [REF(#L, i)]` from the furniture leaf will refer to the location proof stack entry with `i=3`

The proof stack showing that "opening the chest at locationId is fatal" will then be

    0. {LOCATION_CHOICE, [[0], [0, 0], [2, 0], [4, 0]}
    1. {FATAL_CHEST_TRAP, [[REF(0, 3)]]}

The contracts halt the player if a choiceSet is a halting type.
The contracts require stack entries to encode the leaf of an earlier stack item unless they are a LOCATION_CHOICE. So a fatal chest trap entry can only be proven if it includes a reference to a location choice set which is also proven.